### PR TITLE
Accessibility support

### DIFF
--- a/dist/rc-dock.css
+++ b/dist/rc-dock.css
@@ -141,12 +141,12 @@ body > .dragging-layer > div:last-child {
   height: 30px;
   text-align: center;
   transition: color 0.25s cubic-bezier(0.35, 0, 0.25, 1);
-  padding: 0;
+  padding: 0 8px 0 0;
   font-weight: 500;
   border-bottom: 1px solid #ddd;
   cursor: pointer;
   float: left;
-  margin-right: 10px;
+  margin-right: 2px;
   background: #fafafd;
 }
 .dock-tab.dragging {
@@ -209,6 +209,10 @@ body > .dragging-layer > div:last-child {
   flex: 0 0 auto;
   background: #fafafd;
   border-bottom: 1px solid #f3f3f3;
+}
+.dock-top .dock-bar[role=tablist]:focus,
+.dock-top .dock-bar[role=tablist]:focus-within {
+  background-color: rgba(18, 141, 232, 0.15);
 }
 .dock-top .dock-nav-container-scrolling {
   padding-left: 32px;
@@ -278,23 +282,27 @@ body > .dragging-layer > div:last-child {
   cursor: pointer;
   font-family: 'Fredoka One', sans-serif;
   color: #bbb;
-  right: 2px;
+  right: 4px;
   font-size: 12px;
   width: 16px;
   text-align: center;
   top: 6px;
   opacity: 0.3;
+  outline: none;
   transition: all 0.25s ease-in-out;
 }
 .dock-tab-close-btn:before {
   content: "X";
 }
-.dock-tab-close-btn:hover {
+.dock-tab-close-btn:hover,
+.dock-tab-close-btn:focus {
   color: #666;
   transform: scale(1.1, 1.1);
 }
-.dock-tab:hover .dock-tab-close-btn {
+.dock-tab:hover .dock-tab-close-btn,
+.dock-tab-close-btn:focus {
   opacity: 1;
+  color: #108ee9;
 }
 .dock-tab-hit-area {
   position: absolute;
@@ -306,6 +314,9 @@ body > .dragging-layer > div:last-child {
 .dock-pane-cache {
   width: 100%;
   height: 100%;
+}
+.dock > div[role=presentation]:empty {
+  display: none;
 }
 body.dock-dragging {
   user-select: none;
@@ -579,8 +590,10 @@ body.dock-dragging iframe {
   opacity: 0.2;
   cursor: pointer;
   transition: all 0.25s ease-in-out;
+  outline: none;
 }
-.dock-panel-max-btn:hover {
+.dock-panel-max-btn:hover,
+.dock-panel-max-btn:focus {
   opacity: 1;
   transform: scale(1.1, 1.1);
 }
@@ -592,12 +605,20 @@ body.dock-dragging iframe {
   width: 9px;
   height: 9px;
 }
+.dock-panel-max-btn:hover:before,
+.dock-panel-max-btn:focus:before {
+  border-color: #108ee9;
+}
 .dock-mbox .dock-panel-max-btn:before {
   border: none;
   content: "-";
   color: #666;
   font-size: 20px;
   line-height: 4px;
+}
+.dock-mbox .dock-panel-max-btn:focus :before,
+.dock-mbox .dock-panel-max-btn:hover:before :before {
+  color: #108ee9;
 }
 .dock-panel.dock-style-place-holder {
   border: none;

--- a/example/tab-cache.jsx
+++ b/example/tab-cache.jsx
@@ -42,7 +42,7 @@ let box = {
     mode: 'vertical',
     children: [
       {
-        tabs: [{...cachedTab, id: 'cache1'}, {...cachedTab, id: 'cache2'}, jsxTab, htmlTab],
+        tabs: [{...cachedTab, closable: true, id: 'cache1'}, {...cachedTab, id: 'cache2'}, jsxTab, htmlTab],
       },
       {
         tabs: [{...nocachedTab, id: 'nocache1'}, {...nocachedTab, id: 'nocache2'}],

--- a/lib/DockTabs.d.ts
+++ b/lib/DockTabs.d.ts
@@ -12,6 +12,7 @@ export declare class TabCache {
     constructor(context: DockContext);
     setData(data: TabData): boolean;
     onCloseClick: (e: React.MouseEvent<Element, MouseEvent>) => void;
+    onKeyDownCloseBtn: (evt: React.KeyboardEvent<Element>) => boolean;
     onDragStart: (e: DragManager.DragState) => void;
     onDragOver: (e: DragManager.DragState) => void;
     onDragLeave: (e: DragManager.DragState) => void;
@@ -34,6 +35,7 @@ export declare class DockTabs extends React.PureComponent<Props, any> {
     cachedTabs: TabData[];
     updateTabs(tabs: TabData[]): void;
     onMaximizeClick: () => void;
+    onKeyDownMaximizeBtn: (evt: React.KeyboardEvent<Element>) => boolean;
     renderTabBar: () => JSX.Element;
     renderTabContent: () => JSX.Element;
     onTabChange: (activeId: string) => void;

--- a/lib/DockTabs.js
+++ b/lib/DockTabs.js
@@ -19,6 +19,7 @@ const DragDropDiv_1 = require("./dragdrop/DragDropDiv");
 const DockTabBar_1 = require("./DockTabBar");
 const DockTabPane_1 = __importStar(require("./DockTabPane"));
 const Algorithm_1 = require("./Algorithm");
+const KeyCode_1 = __importDefault(require("rc-util/lib/KeyCode"));
 function findParentPanel(element) {
     for (let i = 0; i < 10; ++i) {
         if (!element) {
@@ -42,6 +43,13 @@ class TabCache {
         this.onCloseClick = (e) => {
             this.context.dockMove(this.data, null, 'remove');
             e.stopPropagation();
+        };
+        this.onKeyDownCloseBtn = (evt) => {
+            if (!KeyCode_1.default.isTextModifyingKeyEvent(evt.nativeEvent) || (evt.keyCode != KeyCode_1.default.ENTER && evt.keyCode != KeyCode_1.default.SPACE)) {
+                return false;
+            }
+            this.context.dockMove(this.data, null, 'remove');
+            evt.stopPropagation();
         };
         this.onDragStart = (e) => {
             let panel = findParentPanel(this._ref);
@@ -120,7 +128,7 @@ class TabCache {
         let tab = (react_1.default.createElement("div", { ref: this.getRef },
             title,
             react_1.default.createElement(DragDropDiv_1.DragDropDiv, { className: 'dock-tab-hit-area', getRef: this.getHitAreaRef, onDragStartT: this.onDragStart, onDragOverT: this.onDragOver, onDropT: this.onDrop, onDragLeaveT: this.onDragLeave }, closable ?
-                react_1.default.createElement("div", { className: 'dock-tab-close-btn', onClick: this.onCloseClick })
+                react_1.default.createElement("div", { className: 'dock-tab-close-btn', onClick: this.onCloseClick, onKeyDown: this.onKeyDownCloseBtn, tabIndex: 0 })
                 : null)));
         if (cacheContext) {
             // allow DockTabPane to receive context
@@ -144,6 +152,14 @@ class DockTabs extends react_1.default.PureComponent {
             let { panelData } = this.props;
             this.context.dockMove(panelData, null, 'maximize');
         };
+        this.onKeyDownMaximizeBtn = (evt) => {
+            if (!KeyCode_1.default.isTextModifyingKeyEvent(evt.nativeEvent) || (evt.keyCode != KeyCode_1.default.ENTER && evt.keyCode != KeyCode_1.default.SPACE)) {
+                return false;
+            }
+            evt.stopPropagation();
+            let { panelData } = this.props;
+            this.context.dockMove(panelData, null, 'maximize');
+        };
         this.renderTabBar = () => {
             let { panelData, onPanelDragStart, onPanelDragMove, onPanelDragEnd } = this.props;
             let { group: groupName, panelLock } = panelData;
@@ -159,7 +175,7 @@ class DockTabs extends react_1.default.PureComponent {
                 panelExtraContent = panelExtra(panelData, this.context);
             }
             else if (group.maximizable) {
-                panelExtraContent = (react_1.default.createElement("div", { className: 'dock-panel-max-btn', onClick: this.onMaximizeClick }));
+                panelExtraContent = (react_1.default.createElement("div", { className: 'dock-panel-max-btn', onClick: this.onMaximizeClick, onKeyDown: this.onKeyDownMaximizeBtn, tabIndex: 0 }));
             }
             return (react_1.default.createElement(DockTabBar_1.DockTabBar, { extraContent: panelExtraContent, onDragStart: onPanelDragStart, onDragMove: onPanelDragMove, onDragEnd: onPanelDragEnd }));
         };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "classnames": "^2.2.6",
     "lodash": "^4.17.15",
     "rc-tabs": "^10.0.0-alpha.1",
-    "rc-util": "^4.18.1",
+    "rc-util": "^4.20.1",
     "react-new-window": "^0.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "classnames": "^2.2.6",
     "lodash": "^4.17.15",
     "rc-tabs": "^10.0.0-alpha.1",
+    "rc-util": "^4.18.1",
     "react-new-window": "^0.1.2"
   },
   "devDependencies": {
@@ -64,6 +65,7 @@
     "example": "parcel example/*.html --open --out-dir temp --no-source-maps --no-hmr",
     "build-less": "lessc style/index.less dist/rc-dock.css",
     "build-doc": "typedoc --options ./typedocconfig.js",
-    "build-www": "ts-node tool/build-www"
+    "build-www": "ts-node tool/build-www",
+    "build-ts": "tsc -p tsconfig.json"
   }
 }

--- a/src/DockTabs.tsx
+++ b/src/DockTabs.tsx
@@ -9,6 +9,7 @@ import {DragDropDiv} from "./dragdrop/DragDropDiv";
 import {DockTabBar} from "./DockTabBar";
 import DockTabPane, {getContextPaneClass} from "./DockTabPane";
 import {getFloatPanelSize} from "./Algorithm";
+import KeyCode from 'rc-util/lib/KeyCode';
 
 function findParentPanel(element: HTMLElement) {
   for (let i = 0; i < 10; ++i) {
@@ -56,6 +57,18 @@ export class TabCache {
     this.context.dockMove(this.data, null, 'remove');
     e.stopPropagation();
   };
+
+  onKeyDownCloseBtn = (evt : React.KeyboardEvent) => {
+    if (!KeyCode.isTextModifyingKeyEvent(evt.nativeEvent) || (
+      evt.keyCode != KeyCode.ENTER && evt.keyCode != KeyCode.SPACE
+    )) {
+      return false;
+    }
+
+    this.context.dockMove(this.data, null, 'remove');
+    evt.stopPropagation();
+  };
+
   onDragStart = (e: DragState) => {
     let panel = findParentPanel(this._ref);
     let tabGroup = this.context.getGroup(this.data.group);
@@ -125,7 +138,8 @@ export class TabCache {
                      onDragStartT={this.onDragStart}
                      onDragOverT={this.onDragOver} onDropT={this.onDrop} onDragLeaveT={this.onDragLeave}>
           {closable ?
-            <div className='dock-tab-close-btn' onClick={this.onCloseClick}/>
+            <div className='dock-tab-close-btn' onClick={this.onCloseClick}
+                 onKeyDown={this.onKeyDownCloseBtn} tabIndex={0}/>
             : null
           }
         </DragDropDiv>
@@ -209,6 +223,18 @@ export class DockTabs extends React.PureComponent<Props, any> {
     this.context.dockMove(panelData, null, 'maximize');
   };
 
+  onKeyDownMaximizeBtn = (evt : React.KeyboardEvent) => {
+    if (!KeyCode.isTextModifyingKeyEvent(evt.nativeEvent) || (
+      evt.keyCode != KeyCode.ENTER && evt.keyCode != KeyCode.SPACE
+    )) {
+      return false;
+    }
+
+    evt.stopPropagation();
+    let {panelData} = this.props;
+    this.context.dockMove(panelData, null, 'maximize');
+  };
+
   renderTabBar = () => {
     let {panelData, onPanelDragStart, onPanelDragMove, onPanelDragEnd} = this.props;
     let {group: groupName, panelLock} = panelData;
@@ -226,7 +252,8 @@ export class DockTabs extends React.PureComponent<Props, any> {
       panelExtraContent = panelExtra(panelData, this.context);
     } else if (group.maximizable) {
       panelExtraContent = (
-        <div className='dock-panel-max-btn' onClick={this.onMaximizeClick}/>
+        <div className='dock-panel-max-btn' onClick={this.onMaximizeClick}
+             onKeyDown={this.onKeyDownMaximizeBtn} tabIndex={0}/>
       );
     }
     return (

--- a/style/panel.less
+++ b/style/panel.less
@@ -330,8 +330,10 @@ body.dock-dragging {
   opacity: 0.2;
   cursor: pointer;
   transition: all 0.25s ease-in-out;
+  outline: none;
 
-  &:hover {
+  &:hover,
+  &:focus {
     opacity: 1;
     transform: scale(1.1, 1.1);
   }
@@ -344,16 +346,26 @@ body.dock-dragging {
     width: 9px;
     height: 9px;
   }
+  &:hover,
+  &:focus {
+    &:before {
+      border-color: #108ee9;
+    }
+  }
 }
 
 .dock-mbox .dock-panel-max-btn {
-
-
   &:before {
     border: none;
     content: "-";
     color: #666;
     font-size: 20px;
     line-height: 4px;
+  }
+  &:focus,
+  &:hover {
+    &:before {
+      color: #108ee9;
+    }
   }
 }

--- a/style/tabs.less
+++ b/style/tabs.less
@@ -115,12 +115,12 @@
     height: 30px;
     text-align: center;
     transition: color 0.25s cubic-bezier(0.35, 0, 0.25, 1);
-    padding: 0;
+    padding: 0 8px 0 0;
     font-weight: 500;
     border-bottom: 1px solid #ddd;
     cursor: pointer;
     float: left;
-    margin-right: 10px;
+    margin-right: 2px;
     background: #fafafd;
 
     &.dragging {
@@ -198,6 +198,11 @@
     flex: 0 0 auto;
     background: #fafafd;
     border-bottom: 1px solid #f3f3f3;
+
+    &[role=tablist]:focus,
+    &[role=tablist]:focus-within {
+        background-color: rgba(18, 141, 232, 0.15);
+    }
   }
 
   &-top &-nav-container-scrolling {
@@ -283,12 +288,13 @@
     cursor: pointer;
     font-family: 'Fredoka One', sans-serif;
     color: #bbb;
-    right: 2px;
+    right: 4px;
     font-size: 12px;
     width: 16px;
     text-align: center;
     top: 6px;
     opacity: 0.3;
+    outline: none;
     transition: all 0.25s ease-in-out;
 
     &:before {
@@ -296,13 +302,16 @@
     }
   }
 
-  &-tab-close-btn:hover {
+  &-tab-close-btn:hover,
+  &-tab-close-btn:focus {
     color: #666;
     transform: scale(1.1, 1.1);
   }
 
-  &-tab:hover &-tab-close-btn {
+  &-tab:hover &-tab-close-btn,
+  &-tab-close-btn:focus {
     opacity: 1;
+    color: #108ee9;
   }
 
   &-tab-hit-area {
@@ -316,6 +325,9 @@
   &-pane-cache {
     width: 100%;
     height: 100%;
+  }
+  > div[role=presentation]:empty {
+    display: none;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4365,6 +4365,18 @@ rc-util@^4.0.4:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.1.0"
 
+rc-util@^4.20.1:
+  version "4.20.1"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.20.1.tgz#a5976eabfc3198ed9b8e79ffb8c53c231db36e77"
+  integrity sha512-EGlDg9KPN0POzmAR2hk9ZyFc3DmJIrXwlC8NoDxJguX2LTINnVqwadLIVauLfYgYISMiFYFrSHiFW+cqUhZ5dA==
+  dependencies:
+    add-dom-event-listener "^1.1.0"
+    babel-runtime "6.x"
+    prop-types "^15.5.10"
+    react-is "^16.12.0"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.1.0"
+
 react-dom@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
@@ -4374,6 +4386,11 @@ react-dom@^16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.18.0"
+
+react-is@^16.12.0:
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
+  integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
 
 react-is@^16.8.1:
   version "16.12.0"


### PR DESCRIPTION
Enabled the keyboard navigation on the close and maximise button.

To enable keyboard navigation on the close and maximise buttons, set 'tabIndex' attribute and 'onKeyDown' event for them.

Also - highlighting the 'tablist', which gets focus. It also give clear indication, which tab will be activated, on pressing the navigation shortcut key (i.e UP/LEFT/DOWN/RIGHT). It will improve the user experience.

Please refer pull request #36 
