### PR TITLE
Hide empty DOM elements for better keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "lodash": "^4.17.15",
-    "rc-tabs": "^10.0.0-alpha.1",
+    "rc-tabs": "^10.1.0",
     "rc-util": "^4.20.1",
     "react-new-window": "^0.1.2"
   },

--- a/style/tabs.less
+++ b/style/tabs.less
@@ -321,5 +321,9 @@
     width: 100%;
     height: 100%;
   }
+
+  > div[role=presentation]:empty {
+    display: none;
+  }
 }
 

--- a/style/tabs.less
+++ b/style/tabs.less
@@ -321,9 +321,5 @@
     width: 100%;
     height: 100%;
   }
-
-  > div[role=presentation]:empty {
-    display: none;
-  }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4218,7 +4218,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.9, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.9, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4303,13 +4303,6 @@ quote-stream@^1.0.1, quote-stream@~1.0.2:
     minimist "^1.1.3"
     through2 "^2.0.0"
 
-raf@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -4339,31 +4332,16 @@ rc-hammerjs@~0.6.0:
     hammerjs "^2.0.8"
     prop-types "^15.5.9"
 
-rc-tabs@^10.0.0-alpha.1:
-  version "10.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-10.0.0-alpha.1.tgz#adcae2435fd890bffbc9a7e4a7dac5c4fd7ee5f8"
-  integrity sha512-TgJpxYI3X9aH+/b7ksu24zOIajo7CVJTSwAEYR3SMmg7Tz/dqOONqBQyU7BpAhmq644iqwPgr8rRniUeWwlXCw==
+rc-tabs@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/rc-tabs/-/rc-tabs-10.1.0.tgz#a116cf866235b46e67a7f240a7bca13ea5dceea2"
+  integrity sha512-QykNF6ypxGWYDAbGLQ8Q2UqW/d+RAoGj2Y4vOaml3iPevQk3UoFtXxDgpVlITuLTX1sNmtGzVenxnWwigQrFeA==
   dependencies:
-    babel-runtime "6.x"
     classnames "2.x"
     lodash "^4.17.5"
-    prop-types "15.x"
-    raf "^3.4.1"
     rc-hammerjs "~0.6.0"
-    rc-util "^4.0.4"
     resize-observer-polyfill "^1.5.1"
     warning "^4.0.3"
-
-rc-util@^4.0.4:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.18.1.tgz#5a6312503cd5366ef0bede021dce42d373f404a8"
-  integrity sha512-3aRHG32ZvqBymtJUGoQnbZS+XANzO6XTiFEFAYI3BfuxESEazopAy0kBwcAI6BlLHsW1oLiy3ysE9uYwylh2ag==
-  dependencies:
-    add-dom-event-listener "^1.1.0"
-    babel-runtime "6.x"
-    prop-types "^15.5.10"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
 
 rc-util@^4.20.1:
   version "4.20.1"


### PR DESCRIPTION
Set the CSS 'display: none' for the element 'div[role=presentation]',
having not children.

Element 'div[role=presentation]' is being created by 'rc-tabs', and it
does not have attribute 'tabIndex=0'. And - when keyboard is used for
navigation, it would get the focus.

And - it results into a confusion, as that element is not visible on the
screen, and user could not understand, which element is having focus at
the moment.

Hiding these elements (having no children), will give better user
experience while using keyboard (#36) for navigation.