### PR TITLE
Failed to transpile 'dragdrop/DragManager' using TypeScript 3.8.3

### DIFF
--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -2,7 +2,7 @@ import React, {CSSProperties, PointerEventHandler} from "react";
 import {DockContext, DockContextType, DockMode, PanelData, TabData, TabGroup} from "./DockData";
 import {DockTabs} from "./DockTabs";
 import {AbstractPointerEvent, DragDropDiv} from "./dragdrop/DragDropDiv";
-import {default as DragManager, DragState} from "./dragdrop/DragManager";
+import {DragState} from "./dragdrop/DragManager";
 import {DockDropLayer} from "./DockDropLayer";
 import {getFloatPanelSize, nextZIndex} from "./Algorithm";
 import {DockDropEdge} from "./DockDropEdge";


### PR DESCRIPTION
Resolved an error compiling the typescripts.

I was getting error as below:
----------
$ node_modules/.bin/tsc --build tsconfig.json
src/DockPanel.tsx:5:9 - error TS2305: Module '"../../../../../../Users/asheshvashi/Developments/Projects/rc-dock/src/dragdrop/DragManager"' has no exported member 'default'.

5 import {default as DragManager, DragState} from "./dragdrop/DragManager";
          ~~~~~~~


Found 1 error.
----------