### PR TITLE
Check for the existence of ref before accessing its properties

### DIFF
--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -451,10 +451,13 @@ export class DockLayout extends DockPortalManager implements DockContext {
 
   _onWindowResize: any = debounce(() => {
     let layout = this.tempLayout || this.state.layout;
-    let newLayout = Algorithm.fixFloatPanelPos(layout, this._ref.offsetWidth, this._ref.offsetHeight);
-    if (layout !== newLayout) {
-      newLayout = Algorithm.fixLayoutData(newLayout); // panel parent might need a fix
-      this.changeLayout(newLayout, null);
+
+    if (this._ref) {
+      let newLayout = Algorithm.fixFloatPanelPos(layout, this._ref.offsetWidth, this._ref.offsetHeight);
+      if (layout !== newLayout) {
+        newLayout = Algorithm.fixLayoutData(newLayout); // panel parent might need a fix
+        this.changeLayout(newLayout, null);
+      }
     }
   }, 200);
 


### PR DESCRIPTION
Hi @rinick ,

When StrictMode is enabled in development mode, _onWindowResize listener throws the following error every time resize event fires.

![image](https://user-images.githubusercontent.com/51158937/86609227-90e93b00-bfa3-11ea-8a5c-b1a4e2685f28.png) 

Please see the sandboxes below:
1. [StrictMode enabled]( https://codesandbox.io/s/rc-dock-with-strictmode-3n0x2)
2. [Without StrictMode](https://codesandbox.io/s/rc-dock-without-strictmode-4gcrn)