### PR TITLE
fix: panel flex-grow may less than 1 after multiple layouts

### DIFF
--- a/es/Algorithm.js
+++ b/es/Algorithm.js
@@ -190,7 +190,7 @@ export function dockPanelToPanel(layout, newPanel, panel, direction) {
             if (afterPanel) {
                 ++pos;
             }
-            panel.size *= 0.5;
+            // HINT: The size remains the same, preventing flex-grow less than 1
             newPanel.size = panel.size;
             newBox.children.splice(pos, 0, newPanel);
         }

--- a/lib/Algorithm.js
+++ b/lib/Algorithm.js
@@ -200,7 +200,7 @@ function dockPanelToPanel(layout, newPanel, panel, direction) {
             if (afterPanel) {
                 ++pos;
             }
-            panel.size *= 0.5;
+            // HINT: The size remains the same, preventing flex-grow less than 1
             newPanel.size = panel.size;
             newBox.children.splice(pos, 0, newPanel);
         }

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -221,7 +221,7 @@ export function dockPanelToPanel(layout: LayoutData, newPanel: PanelData, panel:
       if (afterPanel) {
         ++pos;
       }
-      panel.size *= 0.5;
+      // HINT: The size remains the same, preventing flex-grow less than 1
       newPanel.size = panel.size;
       newBox.children.splice(pos, 0, newPanel);
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,15 +2375,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
-
-caniuse-lite@^1.0.30001286:
-  version "1.0.30001300"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz#11ab6c57d3eb6f964cba950401fd00a146786468"
-  integrity sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001286:
+  version "1.0.30001338"
+  resolved "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz"
+  integrity sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
try to fix an issue:

>When I use docMove to add a panel below some panel-A, and then delete it, the panel-A size will be directly halved,
>After a few times like this, the size of panel-A is less than 1.

According to the calculation rules of the panel, when the flex is less than 1, it actually cannot fill the entire area
This causes panel-A to be smaller and smaller.

rule: 
```javascript
// when less than 1, it will not fill the whole area
let flexGrow = flex * size;
```

I don't think the halving is necessary here, so I'm trying to submit this PR, and if the author thinks there are other issues with this, please tell me.

Thank you!


