### PR TITLE
Check if dock layout is mounted when force update on remove tab cache

### DIFF
--- a/es/DockLayout.d.ts
+++ b/es/DockLayout.d.ts
@@ -80,6 +80,7 @@ declare class DockPortalManager extends React.PureComponent<LayoutProps, LayoutS
     /** @ignore */
     _caches: Map<string, TabPaneCache>;
     _pendingDestroy: any;
+    _isMounted: boolean;
     destroyRemovedPane: () => void;
     /** @ignore */
     getTabCache(id: string, owner: any): TabPaneCache;
@@ -134,6 +135,8 @@ export declare class DockLayout extends DockPortalManager implements DockContext
     _onWindowResize: any;
     /** @ignore */
     panelToFocus: string;
+    /** @ignore */
+    componentDidMount(): void;
     /** @ignore
      * move focus to panelToFocus
      */

--- a/es/DockLayout.js
+++ b/es/DockLayout.js
@@ -26,6 +26,7 @@ class DockPortalManager extends React.PureComponent {
         super(...arguments);
         /** @ignore */
         this._caches = new Map();
+        this._isMounted = false;
         this.destroyRemovedPane = () => {
             this._pendingDestroy = null;
             let cacheRemoved = false;
@@ -35,7 +36,7 @@ class DockPortalManager extends React.PureComponent {
                     cacheRemoved = true;
                 }
             }
-            if (cacheRemoved) {
+            if (cacheRemoved && this._isMounted) {
                 this.forceUpdate();
             }
         };
@@ -418,6 +419,10 @@ export class DockLayout extends DockPortalManager {
                 portals),
             React.createElement("div", { className: "dock-drop-indicator", style: dropRectStyle })));
     }
+    /** @ignore */
+    componentDidMount() {
+        this._isMounted = true;
+    }
     /** @ignore
      * move focus to panelToFocus
      */
@@ -437,6 +442,7 @@ export class DockLayout extends DockPortalManager {
         (_a = globalThis.removeEventListener) === null || _a === void 0 ? void 0 : _a.call(globalThis, 'resize', this._onWindowResize);
         DragManager.removeDragStateListener(this.onDragStateChange);
         this._onWindowResize.cancel();
+        this._isMounted = false;
     }
     setLayout(layout) {
         this.tempLayout = layout;

--- a/lib/DockLayout.d.ts
+++ b/lib/DockLayout.d.ts
@@ -80,6 +80,7 @@ declare class DockPortalManager extends React.PureComponent<LayoutProps, LayoutS
     /** @ignore */
     _caches: Map<string, TabPaneCache>;
     _pendingDestroy: any;
+    _isMounted: boolean;
     destroyRemovedPane: () => void;
     /** @ignore */
     getTabCache(id: string, owner: any): TabPaneCache;
@@ -134,6 +135,8 @@ export declare class DockLayout extends DockPortalManager implements DockContext
     _onWindowResize: any;
     /** @ignore */
     panelToFocus: string;
+    /** @ignore */
+    componentDidMount(): void;
     /** @ignore
      * move focus to panelToFocus
      */

--- a/lib/DockLayout.js
+++ b/lib/DockLayout.js
@@ -51,6 +51,7 @@ class DockPortalManager extends react_1.default.PureComponent {
         super(...arguments);
         /** @ignore */
         this._caches = new Map();
+        this._isMounted = false;
         this.destroyRemovedPane = () => {
             this._pendingDestroy = null;
             let cacheRemoved = false;
@@ -60,7 +61,7 @@ class DockPortalManager extends react_1.default.PureComponent {
                     cacheRemoved = true;
                 }
             }
-            if (cacheRemoved) {
+            if (cacheRemoved && this._isMounted) {
                 this.forceUpdate();
             }
         };
@@ -443,6 +444,10 @@ class DockLayout extends DockPortalManager {
                 portals),
             react_1.default.createElement("div", { className: "dock-drop-indicator", style: dropRectStyle })));
     }
+    /** @ignore */
+    componentDidMount() {
+        this._isMounted = true;
+    }
     /** @ignore
      * move focus to panelToFocus
      */
@@ -462,6 +467,7 @@ class DockLayout extends DockPortalManager {
         (_a = globalThis.removeEventListener) === null || _a === void 0 ? void 0 : _a.call(globalThis, 'resize', this._onWindowResize);
         DragManager.removeDragStateListener(this.onDragStateChange);
         this._onWindowResize.cancel();
+        this._isMounted = false;
     }
     setLayout(layout) {
         this.tempLayout = layout;

--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -111,6 +111,8 @@ class DockPortalManager extends React.PureComponent<LayoutProps, LayoutState> {
 
   _pendingDestroy: any;
 
+  _isMounted = false;
+
   destroyRemovedPane = () => {
     this._pendingDestroy = null;
     let cacheRemoved = false;
@@ -120,7 +122,7 @@ class DockPortalManager extends React.PureComponent<LayoutProps, LayoutState> {
         cacheRemoved = true;
       }
     }
-    if (cacheRemoved) {
+    if (cacheRemoved && this._isMounted) {
       this.forceUpdate();
     }
   };
@@ -535,6 +537,11 @@ export class DockLayout extends DockPortalManager implements DockContext {
   /** @ignore */
   panelToFocus: string;
 
+  /** @ignore */
+  componentDidMount() {
+    this._isMounted = true;
+  }
+
   /** @ignore
    * move focus to panelToFocus
    */
@@ -553,6 +560,7 @@ export class DockLayout extends DockPortalManager implements DockContext {
     globalThis.removeEventListener?.('resize', this._onWindowResize);
     DragManager.removeDragStateListener(this.onDragStateChange);
     this._onWindowResize.cancel();
+    this._isMounted = false;
   }
 
   /** @ignore


### PR DESCRIPTION
Hello! This PR fixes the bug related with memory leak when state updates on unmounted component.
I faced with this bug when created dock layout within tab of dock layout (nested dock layouts) and tabs of inner dock layout are cached. 