### PR TITLE
Expose DockTabs' MoreIcon 

### DIFF
--- a/es/DockData.d.ts
+++ b/es/DockData.d.ts
@@ -65,6 +65,10 @@ export interface TabGroup {
      * Override the default flex grow and flex shrink for panel height
      */
     heightFlex?: number;
+    /**
+     * Override the default `moreIcon`
+     */
+    moreIcon?: React.ReactNode;
 }
 /** @ignore */
 export declare const defaultGroup: TabGroup;

--- a/es/DockTabs.js
+++ b/es/DockTabs.js
@@ -243,16 +243,19 @@ export class DockTabs extends React.PureComponent {
     render() {
         let { group, tabs, activeId } = this.props.panelData;
         let tabGroup = this.context.getGroup(group);
-        let { animated } = tabGroup;
+        let { animated, moreIcon } = tabGroup;
         if (animated == null) {
             animated = true;
+        }
+        if (!moreIcon) {
+            moreIcon = "...";
         }
         this.updateTabs(tabs);
         let children = [];
         for (let [id, tab] of this._cache) {
             children.push(tab.content);
         }
-        return (React.createElement(Tabs, { prefixCls: "dock", moreIcon: "...", animated: animated, renderTabBar: this.renderTabBar, activeKey: activeId, onChange: this.onTabChange }, children));
+        return (React.createElement(Tabs, { prefixCls: "dock", moreIcon: moreIcon, animated: animated, renderTabBar: this.renderTabBar, activeKey: activeId, onChange: this.onTabChange }, children));
     }
 }
 DockTabs.contextType = DockContextType;

--- a/lib/DockData.d.ts
+++ b/lib/DockData.d.ts
@@ -65,6 +65,10 @@ export interface TabGroup {
      * Override the default flex grow and flex shrink for panel height
      */
     heightFlex?: number;
+    /**
+     * Override the default `moreIcon`
+     */
+    moreIcon?: React.ReactNode;
 }
 /** @ignore */
 export declare const defaultGroup: TabGroup;

--- a/lib/DockTabs.js
+++ b/lib/DockTabs.js
@@ -269,16 +269,19 @@ class DockTabs extends React.PureComponent {
     render() {
         let { group, tabs, activeId } = this.props.panelData;
         let tabGroup = this.context.getGroup(group);
-        let { animated } = tabGroup;
+        let { animated, moreIcon } = tabGroup;
         if (animated == null) {
             animated = true;
+        }
+        if (!moreIcon) {
+            moreIcon = "...";
         }
         this.updateTabs(tabs);
         let children = [];
         for (let [id, tab] of this._cache) {
             children.push(tab.content);
         }
-        return (React.createElement(rc_tabs_1.default, { prefixCls: "dock", moreIcon: "...", animated: animated, renderTabBar: this.renderTabBar, activeKey: activeId, onChange: this.onTabChange }, children));
+        return (React.createElement(rc_tabs_1.default, { prefixCls: "dock", moreIcon: moreIcon, animated: animated, renderTabBar: this.renderTabBar, activeKey: activeId, onChange: this.onTabChange }, children));
     }
 }
 exports.DockTabs = DockTabs;

--- a/src/DockData.ts
+++ b/src/DockData.ts
@@ -74,6 +74,10 @@ export interface TabGroup {
    * Override the default flex grow and flex shrink for panel height
    */
   heightFlex?: number;
+  /**
+   * Override the default `moreIcon`
+   */
+  moreIcon?: React.ReactNode;
 }
 
 /** @ignore */

--- a/src/DockTabs.tsx
+++ b/src/DockTabs.tsx
@@ -309,9 +309,12 @@ export class DockTabs extends React.PureComponent<Props, any> {
   render(): React.ReactNode {
     let {group, tabs, activeId} = this.props.panelData;
     let tabGroup = this.context.getGroup(group);
-    let {animated} = tabGroup;
+    let {animated, moreIcon} = tabGroup;
     if (animated == null) {
       animated = true;
+    }
+    if(!moreIcon) {
+      moreIcon = "...";
     }
 
     this.updateTabs(tabs);
@@ -323,7 +326,7 @@ export class DockTabs extends React.PureComponent<Props, any> {
 
     return (
       <Tabs prefixCls="dock"
-            moreIcon="..."
+            moreIcon={moreIcon}
             animated={animated}
             renderTabBar={this.renderTabBar}
             activeKey={activeId}

--- a/src/DockTabs.tsx
+++ b/src/DockTabs.tsx
@@ -313,7 +313,7 @@ export class DockTabs extends React.PureComponent<Props, any> {
     if (animated == null) {
       animated = true;
     }
-    if(!moreIcon) {
+    if (!moreIcon) {
       moreIcon = "...";
     }
 


### PR DESCRIPTION
Exposes `moreIcon` prop of `DockTabs` to enable users to provide a custom icon instead of just `...` or provide a custom component with a `dock-ignore` class on it to disable `drag events` on the `more button`. 

There isn't a way to add `drag-ignore` on the `moreIcon` component now. Seems like `rc-tabs` doesn't provide anything either like a custom className for `moreIcon`.  