### PR TITLE
Fix: check the second parent element for `undefined`

### DIFF
--- a/src/DockTabs.tsx
+++ b/src/DockTabs.tsx
@@ -25,7 +25,7 @@ function findParentPanel(element: HTMLElement) {
 }
 
 function isPopupDiv(r: HTMLDivElement): boolean {
-  return (r == null || r.parentElement?.tagName === 'LI' || r.parentElement?.parentElement.tagName === 'LI');
+  return (r == null || r.parentElement?.tagName === 'LI' || r.parentElement?.parentElement?.tagName === 'LI');
 }
 
 export class TabCache {


### PR DESCRIPTION
This is enough to make the library work with [`preact`](https://preactjs.com/). Ref this issue: https://github.com/ticlo/rc-dock/issues/161