### PR TITLE
Associate `dragging-layer` to `tabGroup`. 

### DIFF
--- a/es/DockPanel.js
+++ b/es/DockPanel.js
@@ -52,14 +52,14 @@ export class DockPanel extends React.PureComponent {
                 this._movingX = x;
                 this._movingY = y;
                 // hide the panel, but not create drag layer element
-                event.setData({ panel: this.props.panelData }, dockId);
+                event.setData({ panel: panelData, panelGroup: panelData.group }, dockId);
                 event.startDrag(null, null);
                 this.onFloatPointerDown();
             }
             else {
                 let tabGroup = this.context.getGroup(panelData.group);
                 let [panelWidth, panelHeight] = getFloatPanelSize(this._ref, tabGroup);
-                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight] }, dockId);
+                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight], panelGroup: panelData.group }, dockId);
                 event.startDrag(null);
             }
             this.setState({ draggingHeader: true });

--- a/es/DockPanel.js
+++ b/es/DockPanel.js
@@ -59,7 +59,7 @@ export class DockPanel extends React.PureComponent {
             else {
                 let tabGroup = this.context.getGroup(panelData.group);
                 let [panelWidth, panelHeight] = getFloatPanelSize(this._ref, tabGroup);
-                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight], panelGroup: panelData.group }, dockId);
+                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight], tabGroup: panelData.group }, dockId);
                 event.startDrag(null);
             }
             this.setState({ draggingHeader: true });

--- a/es/DockPanel.js
+++ b/es/DockPanel.js
@@ -52,7 +52,7 @@ export class DockPanel extends React.PureComponent {
                 this._movingX = x;
                 this._movingY = y;
                 // hide the panel, but not create drag layer element
-                event.setData({ panel: panelData, panelGroup: panelData.group }, dockId);
+                event.setData({ panel: panelData, tabGroup: panelData.group }, dockId);
                 event.startDrag(null, null);
                 this.onFloatPointerDown();
             }

--- a/es/DockTabs.js
+++ b/es/DockTabs.js
@@ -52,7 +52,7 @@ export class TabCache {
             let panelElement = findParentPanel(this._ref);
             let tabGroup = this.context.getGroup(this.data.group);
             let [panelWidth, panelHeight] = getFloatPanelSize(panelElement, tabGroup);
-            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight] }, this.context.getDockId());
+            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight], panelGroup: this.data.group }, this.context.getDockId());
             e.startDrag(this._ref.parentElement, this._ref.parentElement);
         };
         this.onDragOver = (e) => {

--- a/es/DockTabs.js
+++ b/es/DockTabs.js
@@ -52,7 +52,7 @@ export class TabCache {
             let panelElement = findParentPanel(this._ref);
             let tabGroup = this.context.getGroup(this.data.group);
             let [panelWidth, panelHeight] = getFloatPanelSize(panelElement, tabGroup);
-            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight], panelGroup: this.data.group }, this.context.getDockId());
+            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight], tabGroup: this.data.group }, this.context.getDockId());
             e.startDrag(this._ref.parentElement, this._ref.parentElement);
         };
         this.onDragOver = (e) => {

--- a/es/dragdrop/DragManager.js
+++ b/es/dragdrop/DragManager.js
@@ -150,12 +150,12 @@ function _createDraggingDiv(doc) {
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
     let classNames = 'dragging-layer ';
-    const panelGroup = _data["panelGroup"];
-    if ((panelGroup === null || panelGroup === void 0 ? void 0 : panelGroup.length) > 0) {
-        classNames += panelGroup
-            .split(" ")
+    const tabGroup = _data['tabGroup'];
+    if ((tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.length) > 0) {
+        classNames += tabGroup
+            .split(' ')
             .map((name) => `dock-style-${name}`)
-            .join(" ");
+            .join(' ');
     }
     _draggingDiv.className = classNames;
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element

--- a/es/dragdrop/DragManager.js
+++ b/es/dragdrop/DragManager.js
@@ -147,17 +147,13 @@ export function removeHandlers(element) {
 let _draggingDiv;
 let _draggingIcon;
 function _createDraggingDiv(doc) {
+    var _a;
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    let classNames = 'dragging-layer ';
     const tabGroup = _data['tabGroup'];
-    if ((tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.length) > 0) {
-        classNames += tabGroup
-            .split(' ')
-            .map((name) => `dock-style-${name}`)
-            .join(' ');
-    }
-    _draggingDiv.className = classNames;
+    _draggingDiv.className = ((_a = tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.split(' ').map((name) => `dock-style-${name}`)) !== null && _a !== void 0 ? _a : [])
+        .concat('dragging-layer')
+        .join(' ');
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
     _draggingDiv.appendChild(_draggingIcon);
 }

--- a/es/dragdrop/DragManager.js
+++ b/es/dragdrop/DragManager.js
@@ -150,7 +150,7 @@ function _createDraggingDiv(doc) {
     var _a;
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    const tabGroup = _data['tabGroup'];
+    const tabGroup = (_data && 'tabGroup' in _data ? _data['tabGroup'] : undefined);
     _draggingDiv.className = ((_a = tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.split(' ').map((name) => `dock-style-${name}`)) !== null && _a !== void 0 ? _a : [])
         .concat('dragging-layer')
         .join(' ');

--- a/es/dragdrop/DragManager.js
+++ b/es/dragdrop/DragManager.js
@@ -146,20 +146,24 @@ export function removeHandlers(element) {
 }
 let _draggingDiv;
 let _draggingIcon;
-function _createDraggingDiv(doc) {
+function _createDraggingDiv(doc, classNames) {
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    _draggingDiv.className = 'dragging-layer';
+    _draggingDiv.className = `dragging-layer ${classNames}`;
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
     _draggingDiv.appendChild(_draggingIcon);
 }
 function createDraggingElement(state, refElement, draggingHtml) {
+    const classNames = (_data["panelGroup"] || "")
+        .split(" ")
+        .map((name) => `dock-style-${name}`)
+        .join(" ");
     _draggingState = state;
     if (refElement) {
         refElement.classList.add('dragging');
         _refElement = refElement;
     }
-    _createDraggingDiv(state.component.ownerDocument);
+    _createDraggingDiv(state.component.ownerDocument, classNames);
     state.component.ownerDocument.body.appendChild(_draggingDiv);
     let draggingWidth = 0;
     let draggingHeight = 0;

--- a/es/dragdrop/DragManager.js
+++ b/es/dragdrop/DragManager.js
@@ -146,24 +146,28 @@ export function removeHandlers(element) {
 }
 let _draggingDiv;
 let _draggingIcon;
-function _createDraggingDiv(doc, classNames) {
+function _createDraggingDiv(doc) {
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    _draggingDiv.className = `dragging-layer ${classNames}`;
+    let classNames = 'dragging-layer ';
+    const panelGroup = _data["panelGroup"];
+    if ((panelGroup === null || panelGroup === void 0 ? void 0 : panelGroup.length) > 0) {
+        classNames += panelGroup
+            .split(" ")
+            .map((name) => `dock-style-${name}`)
+            .join(" ");
+    }
+    _draggingDiv.className = classNames;
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
     _draggingDiv.appendChild(_draggingIcon);
 }
 function createDraggingElement(state, refElement, draggingHtml) {
-    const classNames = (_data["panelGroup"] || "")
-        .split(" ")
-        .map((name) => `dock-style-${name}`)
-        .join(" ");
     _draggingState = state;
     if (refElement) {
         refElement.classList.add('dragging');
         _refElement = refElement;
     }
-    _createDraggingDiv(state.component.ownerDocument, classNames);
+    _createDraggingDiv(state.component.ownerDocument);
     state.component.ownerDocument.body.appendChild(_draggingDiv);
     let draggingWidth = 0;
     let draggingHeight = 0;

--- a/lib/DockPanel.js
+++ b/lib/DockPanel.js
@@ -74,14 +74,14 @@ class DockPanel extends React.PureComponent {
                 this._movingX = x;
                 this._movingY = y;
                 // hide the panel, but not create drag layer element
-                event.setData({ panel: this.props.panelData }, dockId);
+                event.setData({ panel: panelData, panelGroup: panelData.group }, dockId);
                 event.startDrag(null, null);
                 this.onFloatPointerDown();
             }
             else {
                 let tabGroup = this.context.getGroup(panelData.group);
                 let [panelWidth, panelHeight] = Algorithm_1.getFloatPanelSize(this._ref, tabGroup);
-                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight] }, dockId);
+                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight], panelGroup: panelData.group }, dockId);
                 event.startDrag(null);
             }
             this.setState({ draggingHeader: true });

--- a/lib/DockPanel.js
+++ b/lib/DockPanel.js
@@ -74,7 +74,7 @@ class DockPanel extends React.PureComponent {
                 this._movingX = x;
                 this._movingY = y;
                 // hide the panel, but not create drag layer element
-                event.setData({ panel: panelData, panelGroup: panelData.group }, dockId);
+                event.setData({ panel: panelData, tabGroup: panelData.group }, dockId);
                 event.startDrag(null, null);
                 this.onFloatPointerDown();
             }

--- a/lib/DockPanel.js
+++ b/lib/DockPanel.js
@@ -81,7 +81,7 @@ class DockPanel extends React.PureComponent {
             else {
                 let tabGroup = this.context.getGroup(panelData.group);
                 let [panelWidth, panelHeight] = Algorithm_1.getFloatPanelSize(this._ref, tabGroup);
-                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight], panelGroup: panelData.group }, dockId);
+                event.setData({ panel: panelData, panelSize: [panelWidth, panelHeight], tabGroup: panelData.group }, dockId);
                 event.startDrag(null);
             }
             this.setState({ draggingHeader: true });

--- a/lib/DockTabs.js
+++ b/lib/DockTabs.js
@@ -77,7 +77,7 @@ class TabCache {
             let panelElement = findParentPanel(this._ref);
             let tabGroup = this.context.getGroup(this.data.group);
             let [panelWidth, panelHeight] = Algorithm_1.getFloatPanelSize(panelElement, tabGroup);
-            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight] }, this.context.getDockId());
+            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight], panelGroup: this.data.group }, this.context.getDockId());
             e.startDrag(this._ref.parentElement, this._ref.parentElement);
         };
         this.onDragOver = (e) => {

--- a/lib/DockTabs.js
+++ b/lib/DockTabs.js
@@ -77,7 +77,7 @@ class TabCache {
             let panelElement = findParentPanel(this._ref);
             let tabGroup = this.context.getGroup(this.data.group);
             let [panelWidth, panelHeight] = Algorithm_1.getFloatPanelSize(panelElement, tabGroup);
-            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight], panelGroup: this.data.group }, this.context.getDockId());
+            e.setData({ tab: this.data, panelSize: [panelWidth, panelHeight], tabGroup: this.data.group }, this.context.getDockId());
             e.startDrag(this._ref.parentElement, this._ref.parentElement);
         };
         this.onDragOver = (e) => {

--- a/lib/dragdrop/DragManager.js
+++ b/lib/dragdrop/DragManager.js
@@ -157,12 +157,12 @@ function _createDraggingDiv(doc) {
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
     let classNames = 'dragging-layer ';
-    const panelGroup = _data["panelGroup"];
-    if ((panelGroup === null || panelGroup === void 0 ? void 0 : panelGroup.length) > 0) {
-        classNames += panelGroup
-            .split(" ")
+    const tabGroup = _data['tabGroup'];
+    if ((tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.length) > 0) {
+        classNames += tabGroup
+            .split(' ')
             .map((name) => `dock-style-${name}`)
-            .join(" ");
+            .join(' ');
     }
     _draggingDiv.className = classNames;
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element

--- a/lib/dragdrop/DragManager.js
+++ b/lib/dragdrop/DragManager.js
@@ -154,17 +154,13 @@ exports.removeHandlers = removeHandlers;
 let _draggingDiv;
 let _draggingIcon;
 function _createDraggingDiv(doc) {
+    var _a;
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    let classNames = 'dragging-layer ';
     const tabGroup = _data['tabGroup'];
-    if ((tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.length) > 0) {
-        classNames += tabGroup
-            .split(' ')
-            .map((name) => `dock-style-${name}`)
-            .join(' ');
-    }
-    _draggingDiv.className = classNames;
+    _draggingDiv.className = ((_a = tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.split(' ').map((name) => `dock-style-${name}`)) !== null && _a !== void 0 ? _a : [])
+        .concat('dragging-layer')
+        .join(' ');
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
     _draggingDiv.appendChild(_draggingIcon);
 }

--- a/lib/dragdrop/DragManager.js
+++ b/lib/dragdrop/DragManager.js
@@ -157,7 +157,7 @@ function _createDraggingDiv(doc) {
     var _a;
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    const tabGroup = _data['tabGroup'];
+    const tabGroup = (_data && 'tabGroup' in _data ? _data['tabGroup'] : undefined);
     _draggingDiv.className = ((_a = tabGroup === null || tabGroup === void 0 ? void 0 : tabGroup.split(' ').map((name) => `dock-style-${name}`)) !== null && _a !== void 0 ? _a : [])
         .concat('dragging-layer')
         .join(' ');

--- a/lib/dragdrop/DragManager.js
+++ b/lib/dragdrop/DragManager.js
@@ -153,24 +153,28 @@ function removeHandlers(element) {
 exports.removeHandlers = removeHandlers;
 let _draggingDiv;
 let _draggingIcon;
-function _createDraggingDiv(doc, classNames) {
+function _createDraggingDiv(doc) {
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    _draggingDiv.className = `dragging-layer ${classNames}`;
+    let classNames = 'dragging-layer ';
+    const panelGroup = _data["panelGroup"];
+    if ((panelGroup === null || panelGroup === void 0 ? void 0 : panelGroup.length) > 0) {
+        classNames += panelGroup
+            .split(" ")
+            .map((name) => `dock-style-${name}`)
+            .join(" ");
+    }
+    _draggingDiv.className = classNames;
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
     _draggingDiv.appendChild(_draggingIcon);
 }
 function createDraggingElement(state, refElement, draggingHtml) {
-    const classNames = (_data["panelGroup"] || "")
-        .split(" ")
-        .map((name) => `dock-style-${name}`)
-        .join(" ");
     _draggingState = state;
     if (refElement) {
         refElement.classList.add('dragging');
         _refElement = refElement;
     }
-    _createDraggingDiv(state.component.ownerDocument, classNames);
+    _createDraggingDiv(state.component.ownerDocument);
     state.component.ownerDocument.body.appendChild(_draggingDiv);
     let draggingWidth = 0;
     let draggingHeight = 0;

--- a/lib/dragdrop/DragManager.js
+++ b/lib/dragdrop/DragManager.js
@@ -153,20 +153,24 @@ function removeHandlers(element) {
 exports.removeHandlers = removeHandlers;
 let _draggingDiv;
 let _draggingIcon;
-function _createDraggingDiv(doc) {
+function _createDraggingDiv(doc, classNames) {
     _draggingDiv = doc.createElement('div');
     _draggingIcon = doc.createElement('div');
-    _draggingDiv.className = 'dragging-layer';
+    _draggingDiv.className = `dragging-layer ${classNames}`;
     _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
     _draggingDiv.appendChild(_draggingIcon);
 }
 function createDraggingElement(state, refElement, draggingHtml) {
+    const classNames = (_data["panelGroup"] || "")
+        .split(" ")
+        .map((name) => `dock-style-${name}`)
+        .join(" ");
     _draggingState = state;
     if (refElement) {
         refElement.classList.add('dragging');
         _refElement = refElement;
     }
-    _createDraggingDiv(state.component.ownerDocument);
+    _createDraggingDiv(state.component.ownerDocument, classNames);
     state.component.ownerDocument.body.appendChild(_draggingDiv);
     let draggingWidth = 0;
     let draggingHeight = 0;

--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -87,7 +87,7 @@ export class DockPanel extends React.PureComponent<Props, State> {
       this._movingX = x;
       this._movingY = y;
       // hide the panel, but not create drag layer element
-      event.setData({panel: panelData, panelGroup: panelData.group}, dockId);
+      event.setData({panel: panelData, tabGroup: panelData.group}, dockId);
       event.startDrag(null, null);
       this.onFloatPointerDown();
     } else {

--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -87,14 +87,14 @@ export class DockPanel extends React.PureComponent<Props, State> {
       this._movingX = x;
       this._movingY = y;
       // hide the panel, but not create drag layer element
-      event.setData({panel: this.props.panelData}, dockId);
+      event.setData({panel: panelData, panelGroup: panelData.group}, dockId);
       event.startDrag(null, null);
       this.onFloatPointerDown();
     } else {
       let tabGroup = this.context.getGroup(panelData.group);
       let [panelWidth, panelHeight] = getFloatPanelSize(this._ref, tabGroup);
 
-      event.setData({panel: panelData, panelSize: [panelWidth, panelHeight]}, dockId);
+      event.setData({panel: panelData, panelSize: [panelWidth, panelHeight], panelGroup: panelData.group}, dockId);
       event.startDrag(null);
     }
     this.setState({draggingHeader: true});

--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -94,7 +94,7 @@ export class DockPanel extends React.PureComponent<Props, State> {
       let tabGroup = this.context.getGroup(panelData.group);
       let [panelWidth, panelHeight] = getFloatPanelSize(this._ref, tabGroup);
 
-      event.setData({panel: panelData, panelSize: [panelWidth, panelHeight], panelGroup: panelData.group}, dockId);
+      event.setData({panel: panelData, panelSize: [panelWidth, panelHeight], tabGroup: panelData.group}, dockId);
       event.startDrag(null);
     }
     this.setState({draggingHeader: true});

--- a/src/DockTabs.tsx
+++ b/src/DockTabs.tsx
@@ -78,7 +78,7 @@ export class TabCache {
     let tabGroup = this.context.getGroup(this.data.group);
     let [panelWidth, panelHeight] = getFloatPanelSize(panelElement, tabGroup);
 
-    e.setData({tab: this.data, panelSize: [panelWidth, panelHeight]}, this.context.getDockId());
+    e.setData({tab: this.data, panelSize: [panelWidth, panelHeight], panelGroup: this.data.group}, this.context.getDockId());
     e.startDrag(this._ref.parentElement, this._ref.parentElement);
   };
   onDragOver = (e: DragManager.DragState) => {

--- a/src/DockTabs.tsx
+++ b/src/DockTabs.tsx
@@ -78,7 +78,7 @@ export class TabCache {
     let tabGroup = this.context.getGroup(this.data.group);
     let [panelWidth, panelHeight] = getFloatPanelSize(panelElement, tabGroup);
 
-    e.setData({tab: this.data, panelSize: [panelWidth, panelHeight], panelGroup: this.data.group}, this.context.getDockId());
+    e.setData({tab: this.data, panelSize: [panelWidth, panelHeight], tabGroup: this.data.group}, this.context.getDockId());
     e.startDrag(this._ref.parentElement, this._ref.parentElement);
   };
   onDragOver = (e: DragManager.DragState) => {

--- a/src/dragdrop/DragManager.ts
+++ b/src/dragdrop/DragManager.ts
@@ -202,12 +202,12 @@ function _createDraggingDiv(doc: Document) {
   _draggingIcon = doc.createElement('div');
 
   let classNames = 'dragging-layer ';
-  const panelGroup = _data["panelGroup"] as string | undefined;
+  const panelGroup = _data['panelGroup'] as string | undefined;
   if (panelGroup?.length > 0) {
     classNames += panelGroup
-      .split(" ")
+      .split(' ')
       .map((name) => `dock-style-${name}`)
-      .join(" ");
+      .join(' ');
   }
   _draggingDiv.className = classNames;
 

--- a/src/dragdrop/DragManager.ts
+++ b/src/dragdrop/DragManager.ts
@@ -201,15 +201,13 @@ function _createDraggingDiv(doc: Document) {
   _draggingDiv = doc.createElement('div');
   _draggingIcon = doc.createElement('div');
 
-  let classNames = 'dragging-layer ';
   const tabGroup = _data['tabGroup'] as string | undefined;
-  if (tabGroup?.length > 0) {
-    classNames += tabGroup
-      .split(' ')
-      .map((name) => `dock-style-${name}`)
-      .join(' ');
-  }
-  _draggingDiv.className = classNames;
+
+  _draggingDiv.className = (
+    tabGroup?.split(' ').map((name) => `dock-style-${name}`) ?? []
+  )
+    .concat('dragging-layer')
+    .join(' ');
 
   _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
   _draggingDiv.appendChild(_draggingIcon);

--- a/src/dragdrop/DragManager.ts
+++ b/src/dragdrop/DragManager.ts
@@ -201,7 +201,7 @@ function _createDraggingDiv(doc: Document) {
   _draggingDiv = doc.createElement('div');
   _draggingIcon = doc.createElement('div');
 
-  const tabGroup = _data['tabGroup'] as string | undefined;
+  const tabGroup = (_data && 'tabGroup' in _data ? _data['tabGroup'] : undefined) as string | undefined;
 
   _draggingDiv.className = (
     tabGroup?.split(' ').map((name) => `dock-style-${name}`) ?? []

--- a/src/dragdrop/DragManager.ts
+++ b/src/dragdrop/DragManager.ts
@@ -197,27 +197,32 @@ export function removeHandlers(element: HTMLElement) {
 let _draggingDiv: HTMLDivElement;
 let _draggingIcon: HTMLDivElement;
 
-function _createDraggingDiv(doc: Document, classNames?: string) {
+function _createDraggingDiv(doc: Document) {
   _draggingDiv = doc.createElement('div');
   _draggingIcon = doc.createElement('div');
-  _draggingDiv.className = `dragging-layer ${classNames}`
+
+  let classNames = 'dragging-layer ';
+  const panelGroup = _data["panelGroup"] as string | undefined;
+  if (panelGroup?.length > 0) {
+    classNames += panelGroup
+      .split(" ")
+      .map((name) => `dock-style-${name}`)
+      .join(" ");
+  }
+  _draggingDiv.className = classNames;
+
   _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
   _draggingDiv.appendChild(_draggingIcon);
 }
 
 
 function createDraggingElement(state: DragState, refElement: HTMLElement, draggingHtml?: HTMLElement | string) {
- const classNames = ((_data["panelGroup"] as string) || "")
-    .split(" ")
-    .map((name) => `dock-style-${name}`)
-    .join(" ");
-
   _draggingState = state;
   if (refElement) {
     refElement.classList.add('dragging');
     _refElement = refElement;
   }
-  _createDraggingDiv(state.component.ownerDocument, classNames);
+  _createDraggingDiv(state.component.ownerDocument);
   state.component.ownerDocument.body.appendChild(_draggingDiv);
 
   let draggingWidth = 0;

--- a/src/dragdrop/DragManager.ts
+++ b/src/dragdrop/DragManager.ts
@@ -202,9 +202,9 @@ function _createDraggingDiv(doc: Document) {
   _draggingIcon = doc.createElement('div');
 
   let classNames = 'dragging-layer ';
-  const panelGroup = _data['panelGroup'] as string | undefined;
-  if (panelGroup?.length > 0) {
-    classNames += panelGroup
+  const tabGroup = _data['tabGroup'] as string | undefined;
+  if (tabGroup?.length > 0) {
+    classNames += tabGroup
       .split(' ')
       .map((name) => `dock-style-${name}`)
       .join(' ');

--- a/src/dragdrop/DragManager.ts
+++ b/src/dragdrop/DragManager.ts
@@ -197,22 +197,27 @@ export function removeHandlers(element: HTMLElement) {
 let _draggingDiv: HTMLDivElement;
 let _draggingIcon: HTMLDivElement;
 
-function _createDraggingDiv(doc: Document) {
+function _createDraggingDiv(doc: Document, classNames?: string) {
   _draggingDiv = doc.createElement('div');
   _draggingIcon = doc.createElement('div');
-  _draggingDiv.className = 'dragging-layer';
+  _draggingDiv.className = `dragging-layer ${classNames}`
   _draggingDiv.appendChild(document.createElement('div')); // place holder for dragging element
   _draggingDiv.appendChild(_draggingIcon);
 }
 
 
 function createDraggingElement(state: DragState, refElement: HTMLElement, draggingHtml?: HTMLElement | string) {
+ const classNames = ((_data["panelGroup"] as string) || "")
+    .split(" ")
+    .map((name) => `dock-style-${name}`)
+    .join(" ");
+
   _draggingState = state;
   if (refElement) {
     refElement.classList.add('dragging');
     _refElement = refElement;
   }
-  _createDraggingDiv(state.component.ownerDocument);
+  _createDraggingDiv(state.component.ownerDocument, classNames);
   state.component.ownerDocument.body.appendChild(_draggingDiv);
 
   let draggingWidth = 0;
@@ -224,7 +229,6 @@ function createDraggingElement(state: DragState, refElement: HTMLElement, draggi
     draggingWidth = (draggingHtml as HTMLElement).offsetWidth;
     draggingHeight = (draggingHtml as HTMLElement).offsetHeight;
     draggingHtml = (draggingHtml as HTMLElement).outerHTML;
-
   }
   if (draggingHtml) {
     _draggingDiv.firstElementChild.outerHTML = draggingHtml as string;


### PR DESCRIPTION
Adds the `dock-panel` classes to the `dragging-layer` too. 

Currently, we don't have a way to link the `dragging layer` to its `drag element`. When we have multiple panels with different groups and styles, It is not possible for us to style the elements in dragging layers and to align their styles to their parent panels or tabs. 