### PR TITLE
Fix floating window size if min size is set

### DIFF
--- a/es/DockPanel.js
+++ b/es/DockPanel.js
@@ -181,6 +181,8 @@ export class DockPanel extends React.PureComponent {
                     break;
                 }
             }
+            panelData.w = Math.max(panelData.w || 0, panelData.minWidth || 0);
+            panelData.h = Math.max(panelData.h || 0, panelData.minHeight || 0);
             this.forceUpdate();
         };
         this.onPanelCornerDragEnd = (e) => {

--- a/lib/DockPanel.js
+++ b/lib/DockPanel.js
@@ -203,6 +203,8 @@ class DockPanel extends React.PureComponent {
                     break;
                 }
             }
+            panelData.w = Math.max(panelData.w || 0, panelData.minWidth || 0);
+            panelData.h = Math.max(panelData.h || 0, panelData.minHeight || 0);
             this.forceUpdate();
         };
         this.onPanelCornerDragEnd = (e) => {

--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -233,6 +233,9 @@ export class DockPanel extends React.PureComponent<Props, State> {
       }
     }
 
+    panelData.w = Math.max(panelData.w || 0, panelData.minWidth || 0);
+    panelData.h = Math.max(panelData.h || 0, panelData.minHeight || 0);
+
     this.forceUpdate();
   };
   onPanelCornerDragEnd = (e: DragState) => {


### PR DESCRIPTION
Te PR fix floating window size if min size is set. The bug reproduces here: [https://ticlo.github.io/rc-dock/examples/#basic](https://ticlo.github.io/rc-dock/examples/#basic). If transform the tab with title "Min Size" to floating window and resize, it will resize minimum to 150x150, but if we finish resize in 100x100 point related to the floating window, and then we will try to make it bigger, it will happen not right away, because the library remembers size 100x100.