### PR TITLE
Fix tab switch issue

### DIFF
--- a/es/DockPanel.js
+++ b/es/DockPanel.js
@@ -216,9 +216,7 @@ export class DockPanel extends React.PureComponent {
         DockPanel._droppingPanel = panel;
     }
     onDragOverOtherPanel() {
-        if (this.state.dropFromPanel) {
-            this.setState({ dropFromPanel: null });
-        }
+        this.setState({ dropFromPanel: null });
     }
     onPanelCornerDrag(e, corner) {
         let { parent, x, y, w, h } = this.props.panelData;

--- a/lib/DockPanel.js
+++ b/lib/DockPanel.js
@@ -241,9 +241,7 @@ class DockPanel extends React.PureComponent {
         DockPanel._droppingPanel = panel;
     }
     onDragOverOtherPanel() {
-        if (this.state.dropFromPanel) {
-            this.setState({ dropFromPanel: null });
-        }
+        this.setState({ dropFromPanel: null });
     }
     onPanelCornerDrag(e, corner) {
         let { parent, x, y, w, h } = this.props.panelData;

--- a/src/DockPanel.tsx
+++ b/src/DockPanel.tsx
@@ -71,9 +71,7 @@ export class DockPanel extends React.PureComponent<Props, State> {
   };
 
   onDragOverOtherPanel() {
-    if (this.state.dropFromPanel) {
-      this.setState({dropFromPanel: null});
-    }
+    this.setState({dropFromPanel: null});
   }
 
   // used both by dragging head and corner


### PR DESCRIPTION
Possible fixes #200 

I found that onDragOverOtherPanel is called before dropFromPanel state is set when I see issue #200, and miss to set null to dropFromPanel state.
In normal case, it is called after the state is set, and eventually dropFromPanel state is set to null and dock squares disappears.
