### PR TITLE
Fix `find` return type and improve external types

### DIFF
--- a/es/Algorithm.d.ts
+++ b/es/Algorithm.d.ts
@@ -16,7 +16,7 @@ export declare enum Filter {
     AnyTabPanel = 123,
     All = 127
 }
-export declare function find(layout: LayoutData, id: string, filter?: Filter): PanelData | TabData | BoxData;
+export declare function find(layout: LayoutData, id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
 export declare function addNextToTab(layout: LayoutData, source: TabData | PanelData, target: TabData, direction: DropDirection): LayoutData;
 export declare function addTabToPanel(layout: LayoutData, source: TabData | PanelData, panel: PanelData, idx?: number): LayoutData;
 export declare function converToPanel(source: TabData | PanelData): PanelData;

--- a/es/Algorithm.js
+++ b/es/Algorithm.js
@@ -71,12 +71,15 @@ function findInPanel(panel, id, filter) {
             }
         }
     }
-    return null;
+    return undefined;
 }
 function findInBox(box, id, filter) {
     let result;
-    if ((filter | Filter.Box) && box.id === id) {
+    if ((filter | Filter.Box) && (box === null || box === void 0 ? void 0 : box.id) === id) {
         return box;
+    }
+    if (!(box === null || box === void 0 ? void 0 : box.children)) {
+        return undefined;
     }
     for (let child of box.children) {
         if ('children' in child) {

--- a/es/DockData.d.ts
+++ b/es/DockData.d.ts
@@ -243,6 +243,15 @@ export interface LayoutData extends LayoutBase {
     loadedFrom?: LayoutBase;
 }
 export declare type DropDirection = 'left' | 'right' | 'bottom' | 'top' | 'middle' | 'remove' | 'before-tab' | 'after-tab' | 'float' | 'front' | 'maximize' | 'new-window' | 'move' | 'active' | 'update';
+export interface FloatSize {
+    width: number;
+    height: number;
+}
+export interface FloatPosition extends FloatSize {
+    left: number;
+    top: number;
+}
+export declare type LayoutSize = FloatSize;
 export interface DockContext {
     /** @ignore */
     getDockId(): any;
@@ -254,10 +263,7 @@ export interface DockContext {
         clientY: number;
     }, panelSize?: [number, number]): void;
     /** @ignore */
-    getLayoutSize(): {
-        width: number;
-        height: number;
-    };
+    getLayoutSize(): LayoutSize;
     /** @ignore
      * When a state change happen to the layout that's handled locally, like inside DockPanel or DockBox.
      * It still need to tell the context there is a change so DockLayout can call onLayoutChange callback.
@@ -276,12 +282,7 @@ export interface DockContext {
      *  - when direction is 'float', target doesn't matter. If this is called directly from code without any user interaction, source must be PanelData with x,y,w,h properties
      * @param floatPosition position of float panel, used only when direction="float"
      */
-    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: {
-        left: number;
-        top: number;
-        width: number;
-        height: number;
-    }): void;
+    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: FloatPosition): void;
     /**
      * Get the TabGroup defined in defaultLayout
      */

--- a/es/DockData.d.ts
+++ b/es/DockData.d.ts
@@ -289,7 +289,7 @@ export interface DockContext {
     /**
      * Find PanelData or TabData by id
      */
-    find(id: string, filter?: Filter): PanelData | TabData | BoxData;
+    find(id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
     /**
      * Update a tab with new TabData
      * @param id tab id to update

--- a/es/DockLayout.d.ts
+++ b/es/DockLayout.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { BoxData, DockContext, DropDirection, LayoutBase, LayoutData, PanelBase, PanelData, TabBase, TabData, TabGroup, TabPaneCache } from "./DockData";
+import { BoxData, DockContext, DropDirection, FloatPosition, LayoutBase, LayoutData, LayoutSize, PanelBase, PanelData, TabBase, TabData, TabGroup, TabPaneCache } from "./DockData";
 import * as Algorithm from "./Algorithm";
 export interface LayoutProps {
     /**
@@ -109,19 +109,11 @@ export declare class DockLayout extends DockPortalManager implements DockContext
      * @param direction @inheritDoc
      * @param floatPosition @inheritDoc
      */
-    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: {
-        left: number;
-        top: number;
-        width: number;
-        height: number;
-    }): void;
+    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: FloatPosition): void;
     /** @inheritDoc */
     find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
     /** @ignore */
-    getLayoutSize(): {
-        width: number;
-        height: number;
-    };
+    getLayoutSize(): LayoutSize;
     /** @inheritDoc */
     updateTab(id: string, newTab: TabData | null, makeActive?: boolean): boolean;
     /** @inheritDoc */

--- a/es/DockLayout.d.ts
+++ b/es/DockLayout.d.ts
@@ -116,7 +116,7 @@ export declare class DockLayout extends DockPortalManager implements DockContext
         height: number;
     }): void;
     /** @inheritDoc */
-    find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData;
+    find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
     /** @ignore */
     getLayoutSize(): {
         width: number;

--- a/es/DockLayout.js
+++ b/es/DockLayout.js
@@ -197,7 +197,7 @@ export class DockLayout extends DockPortalManager {
         }
         else if (target) {
             if ('tabs' in target) {
-                // pandel target
+                // panel target
                 if (direction === 'middle') {
                     layout = Algorithm.addTabToPanel(layout, source, target);
                 }

--- a/lib/Algorithm.d.ts
+++ b/lib/Algorithm.d.ts
@@ -16,7 +16,7 @@ export declare enum Filter {
     AnyTabPanel = 123,
     All = 127
 }
-export declare function find(layout: LayoutData, id: string, filter?: Filter): PanelData | TabData | BoxData;
+export declare function find(layout: LayoutData, id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
 export declare function addNextToTab(layout: LayoutData, source: TabData | PanelData, target: TabData, direction: DropDirection): LayoutData;
 export declare function addTabToPanel(layout: LayoutData, source: TabData | PanelData, panel: PanelData, idx?: number): LayoutData;
 export declare function converToPanel(source: TabData | PanelData): PanelData;

--- a/lib/Algorithm.js
+++ b/lib/Algorithm.js
@@ -77,12 +77,15 @@ function findInPanel(panel, id, filter) {
             }
         }
     }
-    return null;
+    return undefined;
 }
 function findInBox(box, id, filter) {
     let result;
-    if ((filter | Filter.Box) && box.id === id) {
+    if ((filter | Filter.Box) && (box === null || box === void 0 ? void 0 : box.id) === id) {
         return box;
+    }
+    if (!(box === null || box === void 0 ? void 0 : box.children)) {
+        return undefined;
     }
     for (let child of box.children) {
         if ('children' in child) {

--- a/lib/DockData.d.ts
+++ b/lib/DockData.d.ts
@@ -243,6 +243,15 @@ export interface LayoutData extends LayoutBase {
     loadedFrom?: LayoutBase;
 }
 export declare type DropDirection = 'left' | 'right' | 'bottom' | 'top' | 'middle' | 'remove' | 'before-tab' | 'after-tab' | 'float' | 'front' | 'maximize' | 'new-window' | 'move' | 'active' | 'update';
+export interface FloatSize {
+    width: number;
+    height: number;
+}
+export interface FloatPosition extends FloatSize {
+    left: number;
+    top: number;
+}
+export declare type LayoutSize = FloatSize;
 export interface DockContext {
     /** @ignore */
     getDockId(): any;
@@ -254,10 +263,7 @@ export interface DockContext {
         clientY: number;
     }, panelSize?: [number, number]): void;
     /** @ignore */
-    getLayoutSize(): {
-        width: number;
-        height: number;
-    };
+    getLayoutSize(): LayoutSize;
     /** @ignore
      * When a state change happen to the layout that's handled locally, like inside DockPanel or DockBox.
      * It still need to tell the context there is a change so DockLayout can call onLayoutChange callback.
@@ -276,12 +282,7 @@ export interface DockContext {
      *  - when direction is 'float', target doesn't matter. If this is called directly from code without any user interaction, source must be PanelData with x,y,w,h properties
      * @param floatPosition position of float panel, used only when direction="float"
      */
-    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: {
-        left: number;
-        top: number;
-        width: number;
-        height: number;
-    }): void;
+    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: FloatPosition): void;
     /**
      * Get the TabGroup defined in defaultLayout
      */

--- a/lib/DockData.d.ts
+++ b/lib/DockData.d.ts
@@ -289,7 +289,7 @@ export interface DockContext {
     /**
      * Find PanelData or TabData by id
      */
-    find(id: string, filter?: Filter): PanelData | TabData | BoxData;
+    find(id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
     /**
      * Update a tab with new TabData
      * @param id tab id to update

--- a/lib/DockLayout.d.ts
+++ b/lib/DockLayout.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { BoxData, DockContext, DropDirection, LayoutBase, LayoutData, PanelBase, PanelData, TabBase, TabData, TabGroup, TabPaneCache } from "./DockData";
+import { BoxData, DockContext, DropDirection, FloatPosition, LayoutBase, LayoutData, LayoutSize, PanelBase, PanelData, TabBase, TabData, TabGroup, TabPaneCache } from "./DockData";
 import * as Algorithm from "./Algorithm";
 export interface LayoutProps {
     /**
@@ -109,19 +109,11 @@ export declare class DockLayout extends DockPortalManager implements DockContext
      * @param direction @inheritDoc
      * @param floatPosition @inheritDoc
      */
-    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: {
-        left: number;
-        top: number;
-        width: number;
-        height: number;
-    }): void;
+    dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: FloatPosition): void;
     /** @inheritDoc */
     find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
     /** @ignore */
-    getLayoutSize(): {
-        width: number;
-        height: number;
-    };
+    getLayoutSize(): LayoutSize;
     /** @inheritDoc */
     updateTab(id: string, newTab: TabData | null, makeActive?: boolean): boolean;
     /** @inheritDoc */

--- a/lib/DockLayout.d.ts
+++ b/lib/DockLayout.d.ts
@@ -116,7 +116,7 @@ export declare class DockLayout extends DockPortalManager implements DockContext
         height: number;
     }): void;
     /** @inheritDoc */
-    find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData;
+    find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
     /** @ignore */
     getLayoutSize(): {
         width: number;

--- a/lib/DockLayout.js
+++ b/lib/DockLayout.js
@@ -222,7 +222,7 @@ class DockLayout extends DockPortalManager {
         }
         else if (target) {
             if ('tabs' in target) {
-                // pandel target
+                // panel target
                 if (direction === 'middle') {
                     layout = Algorithm.addTabToPanel(layout, source, target);
                 }

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -80,7 +80,7 @@ export function nextZIndex(current?: number): number {
 }
 
 
-function findInPanel(panel: PanelData, id: string, filter: Filter): PanelData | TabData {
+function findInPanel(panel: PanelData, id: string, filter: Filter): PanelData | TabData | undefined {
   if (panel.id === id && (filter & Filter.Panel)) {
     return panel;
   }
@@ -91,13 +91,16 @@ function findInPanel(panel: PanelData, id: string, filter: Filter): PanelData | 
       }
     }
   }
-  return null;
+  return undefined;
 }
 
-function findInBox(box: BoxData, id: string, filter: Filter): PanelData | TabData | BoxData {
-  let result: PanelData | TabData | BoxData;
-  if ((filter | Filter.Box) && box.id === id) {
+function findInBox(box: BoxData | undefined, id: string, filter: Filter): PanelData | TabData | BoxData | undefined {
+  let result: PanelData | TabData | BoxData | undefined;
+  if ((filter | Filter.Box) && box?.id === id) {
     return box;
+  }
+  if (!box?.children) {
+    return undefined;
   }
   for (let child of box.children) {
     if ('children' in child) {
@@ -130,8 +133,8 @@ export enum Filter {
 }
 
 
-export function find(layout: LayoutData, id: string, filter: Filter = Filter.AnyTabPanel): PanelData | TabData | BoxData {
-  let result: PanelData | TabData | BoxData;
+export function find(layout: LayoutData, id: string, filter: Filter = Filter.AnyTabPanel): PanelData | TabData | BoxData | undefined {
+  let result: PanelData | TabData | BoxData | undefined;
 
   if (filter & Filter.Docked) {
     result = findInBox(layout.dockbox, id, filter);

--- a/src/DockData.ts
+++ b/src/DockData.ts
@@ -357,7 +357,7 @@ export interface DockContext {
   /**
    * Find PanelData or TabData by id
    */
-  find(id: string, filter?: Filter): PanelData | TabData | BoxData;
+  find(id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
 
   /**
    * Update a tab with new TabData

--- a/src/DockData.ts
+++ b/src/DockData.ts
@@ -310,6 +310,18 @@ export type DropDirection =
   | 'update' // tab updated with updateTab
   ;
 
+export interface FloatSize {
+  width: number;
+  height: number;
+}
+
+export interface FloatPosition extends FloatSize {
+  left: number;
+  top: number;
+}
+
+export type LayoutSize = FloatSize;
+
 export interface DockContext {
   /** @ignore */
   getDockId(): any;
@@ -321,7 +333,7 @@ export interface DockContext {
   setDropRect(element: HTMLElement, direction?: DropDirection, source?: any, event?: {clientX: number, clientY: number}, panelSize?: [number, number]): void;
 
   /** @ignore */
-  getLayoutSize(): {width: number, height: number};
+  getLayoutSize(): LayoutSize;
 
   /** @ignore
    * When a state change happen to the layout that's handled locally, like inside DockPanel or DockBox.
@@ -346,7 +358,7 @@ export interface DockContext {
     source: TabData | PanelData,
     target: string | TabData | PanelData | BoxData | null,
     direction: DropDirection,
-    floatPosition?: { left: number, top: number, width: number, height: number }
+    floatPosition?: FloatPosition
   ): void;
 
   /**
@@ -389,7 +401,7 @@ export interface DockContext {
 }
 
 /** @ignore */
-export const DockContextType = React.createContext<DockContext>(null);
+export const DockContextType = React.createContext<DockContext>(null!);
 /** @ignore */
 export const DockContextProvider = DockContextType.Provider;
 /** @ignore */

--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -249,7 +249,7 @@ export class DockLayout extends DockPortalManager implements DockContext {
       layout = Algorithm.panelToWindow(layout, newPanel);
     } else if (target) {
       if ('tabs' in (target as PanelData)) {
-        // pandel target
+        // panel target
         if (direction === 'middle') {
           layout = Algorithm.addTabToPanel(layout, source, target as PanelData);
         } else {
@@ -275,7 +275,7 @@ export class DockLayout extends DockPortalManager implements DockContext {
   }
 
   /** @inheritDoc */
-  find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData {
+  find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined {
     return Algorithm.find(this.getLayout(), id, filter);
   }
 

--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -7,8 +7,10 @@ import {
   DockContext,
   DockContextProvider,
   DropDirection,
+  FloatPosition,
   LayoutBase,
   LayoutData,
+  LayoutSize,
   PanelBase,
   PanelData,
   placeHolderGroup,
@@ -215,7 +217,7 @@ export class DockLayout extends DockPortalManager implements DockContext {
     source: TabData | PanelData,
     target: string | TabData | PanelData | BoxData | null,
     direction: DropDirection,
-    floatPosition?: {left: number, top: number, width: number, height: number}
+    floatPosition?: FloatPosition
   ) {
     let layout = this.getLayout();
     if (direction === 'maximize') {
@@ -280,7 +282,7 @@ export class DockLayout extends DockPortalManager implements DockContext {
   }
 
   /** @ignore */
-  getLayoutSize() {
+  getLayoutSize(): LayoutSize {
     if (this._ref) {
       return {width: this._ref.offsetWidth, height: this._ref.offsetHeight};
     }


### PR DESCRIPTION
Possible Fix #204:
- fixes `find` function return type to include _undefined_ when not found.
- improves externally available types.

The code changes conform to the `strict` TypeScript setting.
Each of the fix and improvement are in separate commits so I can split into separate PRs if that helps.