### PR TITLE
Debounce calls to updateTabCache

### DIFF
--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -156,13 +156,13 @@ class DockPortalManager extends React.PureComponent<LayoutProps, LayoutState> {
   }
 
   /** @ignore */
-  updateTabCache(id: string, children: React.ReactNode): void {
+  updateTabCache = debounce((id: string, children: React.ReactNode): void {
     let cache = this._caches.get(id);
     if (cache) {
       cache.portal = ReactDOM.createPortal(children, cache.div, cache.id);
       this.forceUpdate();
     }
-  }
+  }, 200);
 }
 
 export class DockLayout extends DockPortalManager implements DockContext {


### PR DESCRIPTION
Debounce calls to updateTabCache to prevent "Maximum update depth exceeded" errors as seen in this issue: https://github.com/ticlo/rc-dock/issues/198