### PR TITLE
Fix DockLayout.updateTabCache 

### DIFF
--- a/es/DockLayout.js
+++ b/es/DockLayout.js
@@ -68,8 +68,12 @@ class DockPortalManager extends React.PureComponent {
     }
     /** @ignore */
     updateTabCache(id, children) {
+        var _a;
         let cache = this._caches.get(id);
         if (cache) {
+            if (Object.is((_a = cache.portal) === null || _a === void 0 ? void 0 : _a.children, children)) {
+                return;
+            }
             cache.portal = ReactDOM.createPortal(children, cache.div, cache.id);
             this.forceUpdate();
         }

--- a/lib/DockLayout.js
+++ b/lib/DockLayout.js
@@ -93,8 +93,12 @@ class DockPortalManager extends React.PureComponent {
     }
     /** @ignore */
     updateTabCache(id, children) {
+        var _a;
         let cache = this._caches.get(id);
         if (cache) {
+            if (Object.is((_a = cache.portal) === null || _a === void 0 ? void 0 : _a.children, children)) {
+                return;
+            }
             cache.portal = ReactDOM.createPortal(children, cache.div, cache.id);
             this.forceUpdate();
         }

--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -162,7 +162,7 @@ class DockPortalManager extends React.PureComponent<LayoutProps, LayoutState> {
     let cache = this._caches.get(id);
     if (cache) {
       if (Object.is(cache.portal?.children, children)) { 
-        return 
+        return;
       }
       cache.portal = ReactDOM.createPortal(children, cache.div, cache.id);
       this.forceUpdate();

--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -161,6 +161,9 @@ class DockPortalManager extends React.PureComponent<LayoutProps, LayoutState> {
   updateTabCache(id: string, children: React.ReactNode): void {
     let cache = this._caches.get(id);
     if (cache) {
+      if (Object.is(cache.portal?.children, children)) { 
+        return 
+      }
       cache.portal = ReactDOM.createPortal(children, cache.div, cache.id);
       this.forceUpdate();
     }


### PR DESCRIPTION
Fixes #198, #195 

This seems to be a problem with useEffect running twice in React 18 StrictMode.

Fixed it by adding an equality check on current cache and given children to update. 
Only update the cache (and forceUpdate) if they are not same. 