### PR TITLE
Added ability to provide function to find to find by other than id

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ dockMove(source: TabData | PanelData, target: string | TabData | PanelData | Box
 find PanelData or TabData by id
 
 ```typescript
-find(id: string): PanelData | TabData;
+find(id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Filter): PanelData | TabData | BoxData | undefined;
 ```
 
 ### updateTab [🗎](https://ticlo.github.io/rc-dock/classes/docklayout.docklayout-1.html#updatetab)

--- a/es/Algorithm.d.ts
+++ b/es/Algorithm.d.ts
@@ -16,7 +16,7 @@ export declare enum Filter {
     AnyTabPanel = 123,
     All = 127
 }
-export declare function find(layout: LayoutData, id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
+export declare function find(layout: LayoutData, id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Filter): PanelData | TabData | BoxData | undefined;
 export declare function addNextToTab(layout: LayoutData, source: TabData | PanelData, target: TabData, direction: DropDirection): LayoutData;
 export declare function addTabToPanel(layout: LayoutData, source: TabData | PanelData, panel: PanelData, idx?: number): LayoutData;
 export declare function converToPanel(source: TabData | PanelData): PanelData;

--- a/es/Algorithm.js
+++ b/es/Algorithm.js
@@ -60,13 +60,16 @@ export function nextZIndex(current) {
     }
     return ++_zCount;
 }
+function compareFindId(item, id) {
+    return item && (typeof id === 'function' ? id(item) : item.id === id);
+}
 function findInPanel(panel, id, filter) {
-    if (panel.id === id && (filter & Filter.Panel)) {
+    if (compareFindId(panel, id) && (filter & Filter.Panel)) {
         return panel;
     }
     if (filter & Filter.Tab) {
         for (let tab of panel.tabs) {
-            if (tab.id === id) {
+            if (compareFindId(tab, id)) {
                 return tab;
             }
         }
@@ -75,7 +78,7 @@ function findInPanel(panel, id, filter) {
 }
 function findInBox(box, id, filter) {
     let result;
-    if ((filter | Filter.Box) && (box === null || box === void 0 ? void 0 : box.id) === id) {
+    if ((filter | Filter.Box) && compareFindId(box, id)) {
         return box;
     }
     if (!(box === null || box === void 0 ? void 0 : box.children)) {

--- a/es/DockData.d.ts
+++ b/es/DockData.d.ts
@@ -290,7 +290,7 @@ export interface DockContext {
     /**
      * Find PanelData or TabData by id
      */
-    find(id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
+    find(id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Filter): PanelData | TabData | BoxData | undefined;
     /**
      * Update a tab with new TabData
      * @param id tab id to update

--- a/es/DockLayout.d.ts
+++ b/es/DockLayout.d.ts
@@ -111,7 +111,7 @@ export declare class DockLayout extends DockPortalManager implements DockContext
      */
     dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: FloatPosition): void;
     /** @inheritDoc */
-    find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
+    find(id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
     /** @ignore */
     getLayoutSize(): LayoutSize;
     /** @inheritDoc */

--- a/lib/Algorithm.d.ts
+++ b/lib/Algorithm.d.ts
@@ -16,7 +16,7 @@ export declare enum Filter {
     AnyTabPanel = 123,
     All = 127
 }
-export declare function find(layout: LayoutData, id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
+export declare function find(layout: LayoutData, id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Filter): PanelData | TabData | BoxData | undefined;
 export declare function addNextToTab(layout: LayoutData, source: TabData | PanelData, target: TabData, direction: DropDirection): LayoutData;
 export declare function addTabToPanel(layout: LayoutData, source: TabData | PanelData, panel: PanelData, idx?: number): LayoutData;
 export declare function converToPanel(source: TabData | PanelData): PanelData;

--- a/lib/Algorithm.js
+++ b/lib/Algorithm.js
@@ -66,13 +66,16 @@ function nextZIndex(current) {
     return ++_zCount;
 }
 exports.nextZIndex = nextZIndex;
+function compareFindId(item, id) {
+    return item && (typeof id === 'function' ? id(item) : item.id === id);
+}
 function findInPanel(panel, id, filter) {
-    if (panel.id === id && (filter & Filter.Panel)) {
+    if (compareFindId(panel, id) && (filter & Filter.Panel)) {
         return panel;
     }
     if (filter & Filter.Tab) {
         for (let tab of panel.tabs) {
-            if (tab.id === id) {
+            if (compareFindId(tab, id)) {
                 return tab;
             }
         }
@@ -81,7 +84,7 @@ function findInPanel(panel, id, filter) {
 }
 function findInBox(box, id, filter) {
     let result;
-    if ((filter | Filter.Box) && (box === null || box === void 0 ? void 0 : box.id) === id) {
+    if ((filter | Filter.Box) && compareFindId(box, id)) {
         return box;
     }
     if (!(box === null || box === void 0 ? void 0 : box.children)) {

--- a/lib/DockData.d.ts
+++ b/lib/DockData.d.ts
@@ -290,7 +290,7 @@ export interface DockContext {
     /**
      * Find PanelData or TabData by id
      */
-    find(id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
+    find(id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Filter): PanelData | TabData | BoxData | undefined;
     /**
      * Update a tab with new TabData
      * @param id tab id to update

--- a/lib/DockLayout.d.ts
+++ b/lib/DockLayout.d.ts
@@ -111,7 +111,7 @@ export declare class DockLayout extends DockPortalManager implements DockContext
      */
     dockMove(source: TabData | PanelData, target: string | TabData | PanelData | BoxData | null, direction: DropDirection, floatPosition?: FloatPosition): void;
     /** @inheritDoc */
-    find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
+    find(id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined;
     /** @ignore */
     getLayoutSize(): LayoutSize;
     /** @inheritDoc */

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -79,14 +79,18 @@ export function nextZIndex(current?: number): number {
   return ++_zCount;
 }
 
+function compareFindId(item: PanelData | TabData | BoxData, id: string | ((item: PanelData | TabData | BoxData) => boolean)): boolean {
+  return item && (typeof id === 'function' ? id(item) : item.id === id);
+}
 
-function findInPanel(panel: PanelData, id: string, filter: Filter): PanelData | TabData | undefined {
-  if (panel.id === id && (filter & Filter.Panel)) {
+
+function findInPanel(panel: PanelData, id: string | ((item: PanelData | TabData | BoxData) => boolean), filter: Filter): PanelData | TabData | undefined {
+  if (compareFindId(panel, id) && (filter & Filter.Panel)) {
     return panel;
   }
   if (filter & Filter.Tab) {
     for (let tab of panel.tabs) {
-      if (tab.id === id) {
+      if (compareFindId(tab, id)) {
         return tab;
       }
     }
@@ -94,9 +98,9 @@ function findInPanel(panel: PanelData, id: string, filter: Filter): PanelData | 
   return undefined;
 }
 
-function findInBox(box: BoxData | undefined, id: string, filter: Filter): PanelData | TabData | BoxData | undefined {
+function findInBox(box: BoxData | undefined, id: string | ((item: PanelData | TabData | BoxData) => boolean), filter: Filter): PanelData | TabData | BoxData | undefined {
   let result: PanelData | TabData | BoxData | undefined;
-  if ((filter | Filter.Box) && box?.id === id) {
+  if ((filter | Filter.Box) && compareFindId(box, id)) {
     return box;
   }
   if (!box?.children) {
@@ -133,7 +137,7 @@ export enum Filter {
 }
 
 
-export function find(layout: LayoutData, id: string, filter: Filter = Filter.AnyTabPanel): PanelData | TabData | BoxData | undefined {
+export function find(layout: LayoutData, id: string | ((item: PanelData | TabData | BoxData) => boolean), filter: Filter = Filter.AnyTabPanel): PanelData | TabData | BoxData | undefined {
   let result: PanelData | TabData | BoxData | undefined;
 
   if (filter & Filter.Docked) {

--- a/src/DockData.ts
+++ b/src/DockData.ts
@@ -369,7 +369,7 @@ export interface DockContext {
   /**
    * Find PanelData or TabData by id
    */
-  find(id: string, filter?: Filter): PanelData | TabData | BoxData | undefined;
+  find(id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Filter): PanelData | TabData | BoxData | undefined;
 
   /**
    * Update a tab with new TabData

--- a/src/DockLayout.tsx
+++ b/src/DockLayout.tsx
@@ -277,7 +277,7 @@ export class DockLayout extends DockPortalManager implements DockContext {
   }
 
   /** @inheritDoc */
-  find(id: string, filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined {
+  find(id: string | ((item: PanelData | TabData | BoxData) => boolean), filter?: Algorithm.Filter): PanelData | TabData | BoxData | undefined {
     return Algorithm.find(this.getLayout(), id, filter);
   }
 


### PR DESCRIPTION
Added ability to provide a function to `dockLayout.find` instead of just an `id`. The function's first parameter is the box, panel, or tab being considered. The function returns true if the box/panel/tab matches and should be returned by the `find` function.

I called the parameter 'item' because I didn't know what is normal to call that kind of thing. Whatever name makes sense sounds good to me.

I updated `find`'s signature but not the JSDocs.

I added this because I needed a way to search for a tab by function. This implementation is not necessarily the best way to do this (you're free to change it as you'd like), but this was just an easy way I thought of that would also keep backward compatibility.

Thanks for the hard work on `rc-dock`!!