### PR TITLE
Fixed find filter always matching Filter.Box, always running find function against panel even when irrelevant

### DIFF
--- a/es/Algorithm.js
+++ b/es/Algorithm.js
@@ -64,7 +64,7 @@ function compareFindId(item, id) {
     return item && (typeof id === 'function' ? id(item) : item.id === id);
 }
 function findInPanel(panel, id, filter) {
-    if (compareFindId(panel, id) && (filter & Filter.Panel)) {
+    if ((filter & Filter.Panel) && compareFindId(panel, id)) {
         return panel;
     }
     if (filter & Filter.Tab) {
@@ -78,7 +78,7 @@ function findInPanel(panel, id, filter) {
 }
 function findInBox(box, id, filter) {
     let result;
-    if ((filter | Filter.Box) && compareFindId(box, id)) {
+    if ((filter & Filter.Box) && compareFindId(box, id)) {
         return box;
     }
     if (!(box === null || box === void 0 ? void 0 : box.children)) {

--- a/lib/Algorithm.js
+++ b/lib/Algorithm.js
@@ -70,7 +70,7 @@ function compareFindId(item, id) {
     return item && (typeof id === 'function' ? id(item) : item.id === id);
 }
 function findInPanel(panel, id, filter) {
-    if (compareFindId(panel, id) && (filter & Filter.Panel)) {
+    if ((filter & Filter.Panel) && compareFindId(panel, id)) {
         return panel;
     }
     if (filter & Filter.Tab) {
@@ -84,7 +84,7 @@ function findInPanel(panel, id, filter) {
 }
 function findInBox(box, id, filter) {
     let result;
-    if ((filter | Filter.Box) && compareFindId(box, id)) {
+    if ((filter & Filter.Box) && compareFindId(box, id)) {
         return box;
     }
     if (!(box === null || box === void 0 ? void 0 : box.children)) {

--- a/src/Algorithm.ts
+++ b/src/Algorithm.ts
@@ -85,7 +85,7 @@ function compareFindId(item: PanelData | TabData | BoxData, id: string | ((item:
 
 
 function findInPanel(panel: PanelData, id: string | ((item: PanelData | TabData | BoxData) => boolean), filter: Filter): PanelData | TabData | undefined {
-  if (compareFindId(panel, id) && (filter & Filter.Panel)) {
+  if ((filter & Filter.Panel) && compareFindId(panel, id)) {
     return panel;
   }
   if (filter & Filter.Tab) {
@@ -100,7 +100,7 @@ function findInPanel(panel: PanelData, id: string | ((item: PanelData | TabData 
 
 function findInBox(box: BoxData | undefined, id: string | ((item: PanelData | TabData | BoxData) => boolean), filter: Filter): PanelData | TabData | BoxData | undefined {
   let result: PanelData | TabData | BoxData | undefined;
-  if ((filter | Filter.Box) && compareFindId(box, id)) {
+  if ((filter & Filter.Box) && compareFindId(box, id)) {
     return box;
   }
   if (!box?.children) {


### PR DESCRIPTION
- [Bug fix] Flipped the bitwise comparison with `Filter.Box` from `|` to `&` so boxes are properly only eligible for finding if `Filter.Box` is in the filter
  - Note: previously, `Filter.AnyTabPanel` was effectively the same as `Filter.All`. Now, they are appropriately different. This change technically does change how the default `find` filter works because the default is `Filter.AnyTabPanel`. Now, instead of incorrectly matching boxes as well as tabs and panels, it correctly only matches tabs and panels. I suppose you can decide if you want to change the default to `Filter.All` to preserve functionality (otherwise, this bug fix is sorta a breaking change). I don't know if many people would really be affected by this change, however, because I was the one who made the PR for allowing the `id` parameter to be a function, and providing a function for `id` is likely the only situation in which this `Filter` functionality change would make a difference. I might be the first to encounter a problem with this because it might not actually matter for anyone else.
- [Efficiency improvement] Swapped the conditions for matching against panels to match the others; now, the comparison short-circuits and doesn't run the comparison function on the panel if `Filter.Panel` is not in the filter

Thanks!